### PR TITLE
add a TextAttribute to links when available.

### DIFF
--- a/Sources/MarkdownUI/Renderer/TextInlineRenderer.swift
+++ b/Sources/MarkdownUI/Renderer/TextInlineRenderer.swift
@@ -107,15 +107,23 @@ private struct TextInlineRenderer {
   }
 
   private mutating func defaultRender(_ inline: InlineNode) {
-    self.result =
-      self.result
-      + Text(
-        inline.renderAttributedString(
-          baseURL: self.baseURL,
-          textStyles: self.textStyles,
-          softBreakMode: self.softBreakMode,
-          attributes: self.attributes
-        )
+    var text = Text(
+      inline.renderAttributedString(
+        baseURL: self.baseURL,
+        textStyles: self.textStyles,
+        softBreakMode: self.softBreakMode,
+        attributes: self.attributes
       )
+    )
+    if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *), case .link(let destination, _) = inline {
+      text = text.customAttribute(LinkAttribute(urlString: destination))
+    }
+
+    self.result = self.result + text
   }
+}
+
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+public struct LinkAttribute: TextAttribute {
+  public let urlString: String
 }


### PR DESCRIPTION
This allows the app using the library to add a pressed state for links. See https://github.com/gonzalezreal/swift-markdown-ui/discussions/272

This is a copy of https://github.com/gonzalezreal/swift-markdown-ui/pull/417